### PR TITLE
Tutorial 06: remove useless item from "Equation 6.7" legend

### DIFF
--- a/Documents/Positioning/AngleAxisRotationMatrix.mathml
+++ b/Documents/Positioning/AngleAxisRotationMatrix.mathml
@@ -62,18 +62,6 @@
                 </mrow>
               </mfenced>
             </mtd>
-            <mtd>
-              <mi>iS</mi>
-              <mo>=</mo>
-              <mn>1</mn>
-              <mo>-</mo>
-              <mi>sin</mi><mo>&#x2061;</mo>
-              <mfenced open="(" close=")" separators=",">
-                <mrow>
-                  <mi>&#x03B8;</mi>
-                </mrow>
-              </mfenced>
-            </mtd>
           </mtr>
         </mtable>
       </mtd>


### PR DESCRIPTION
Inverted sine "iS" is not actually used in rotation matrix definition (nor should it be: https://en.wikipedia.org/wiki/Rotation_matrix#Rotation_matrix_from_axis_and_angle).